### PR TITLE
Cambios resolución ZAH-211

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,9 @@
+## v0.1.17 (01-04-2022)
+### Bug Fixes
+- Se controla posible NPE al obtener path de evidencias
+- Se controle posible NPE al construir objeto Browser
+
+### Features
+- ZAH-211: Importar evolución framework "viejo Zahorí"
+	> Utilizar emulación de dispositivo móvil en Google Chrome a través de propiedad en zahori.properties [zahori.webdriver.emulated.device.name]
+	> Inyección capabilities con nombre del test en ejecución a través de tag {{testName}}

--- a/src/main/java/io/zahori/framework/core/Browser.java
+++ b/src/main/java/io/zahori/framework/core/Browser.java
@@ -73,7 +73,7 @@ public class Browser {
         this.testContext = testContext;
         createLocalServices();
         createDriver();
-        mainDriverHandle = driver.getWindowHandle();
+        mainDriverHandle = driver != null ? driver.getWindowHandle() : StringUtils.EMPTY;
         activeDriverHandle = mainDriverHandle;
         this.allDrivers = new HashMap<>();
         allDrivers.put(mainDriverHandle, driver);
@@ -157,7 +157,7 @@ public class Browser {
             DesiredCapabilities caps = (DesiredCapabilities) ((RemoteWebDriver) driver).getCapabilities();
             caps.setCapability(CapabilityType.PROXY, proxy);
             try {
-                driver = wbs.getDriver(caps);
+                driver = wbs.getDriver(caps, null);
             } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException e1) {
                 LOG.error("Error al cargar el driver: " + e1.getMessage());
             }
@@ -210,14 +210,19 @@ public class Browser {
                 //				this.wbs = testContext.isHarEnabled() ? new WebDriverBrowserSelenium(browsers, testContext.getProxy4Driver())
                 //						: new WebDriverBrowserSelenium(browsers);
 
-                this.driver = wbs.getWebDriver();
+                String emulatedDevice = testContext.zahoriProperties.getEmulatedDeviceName();
+                this.driver = StringUtils.isBlank(emulatedDevice) ? wbs.getWebDriver() : wbs.getWebDriver(emulatedDevice);
             }
             this.testContext.driver = driver;
         }
     }
 
     public WebDriver createNewWindow() {
-        WebDriver newDriver = wbs.getWebDriver();
+    	return createNewWindow(null);
+    }
+    
+    public WebDriver createNewWindow(String mobileDevice) {
+        WebDriver newDriver = StringUtils.isEmpty(mobileDevice) ? wbs.getWebDriver() : wbs.getWebDriver(mobileDevice);
         activeDriverHandle = newDriver.getWindowHandle();
         allDrivers.put(activeDriverHandle, newDriver);
         testContext.driver = newDriver;

--- a/src/main/java/io/zahori/framework/core/TestContext.java
+++ b/src/main/java/io/zahori/framework/core/TestContext.java
@@ -575,7 +575,7 @@ public class TestContext {
     }
 
     public String getEvidencesFolder() {
-        return evidences.getEvidencesPath();
+        return evidences == null ? null : evidences.getEvidencesPath();
     }
 
     private Notification showGenericNotification(int msDuration, int pixelsWidth, int pixelsHeight, String description, String... descriptionArgs) {

--- a/src/main/java/io/zahori/framework/driver/browserfactory/CapsBrowserSelenium.java
+++ b/src/main/java/io/zahori/framework/driver/browserfactory/CapsBrowserSelenium.java
@@ -73,6 +73,8 @@ public class CapsBrowserSelenium extends DesiredCapabilities {
     private static final String WEBDRIVER_MARIONETTE_BINARY_PATH_UNIX = "webdriver.marionette.firefox.binary.path.unix";
 
     private static final String MAX_FIREFOX_LEGACY_VERSION = "47.0.1";
+    
+    private static final String TEST_NAME_TAG = "{{testName}}";
 
     private static final Logger LOG = Logger.getLogger(CapsBrowserSelenium.class);
 
@@ -100,7 +102,7 @@ public class CapsBrowserSelenium extends DesiredCapabilities {
                 if (isBoolean(extraCapabilities.get(extraCap))) {
                     caps.setCapability(extraCap, Boolean.valueOf(extraCapabilities.get(extraCap)));
                 } else {
-                    caps.setCapability(extraCap, extraCapabilities.get(extraCap));
+                    caps.setCapability(extraCap, translateCap(extraCapabilities.get(extraCap)));
                 }
             }
             caps.setVersion(browsers.getVersion());
@@ -256,6 +258,12 @@ public class CapsBrowserSelenium extends DesiredCapabilities {
 
     private boolean isBoolean(String input) {
         return StringUtils.equalsIgnoreCase("true", input) || StringUtils.equalsIgnoreCase("false", input);
+    }
+    
+    private String translateCap(String originalValue) {
+        return StringUtils.containsIgnoreCase(originalValue,TEST_NAME_TAG)
+                ? originalValue.replace(TEST_NAME_TAG, browsers.getTestName())
+                        : originalValue;
     }
 
 }

--- a/src/main/java/io/zahori/framework/driver/browserfactory/WebDriverBrowserSelenium.java
+++ b/src/main/java/io/zahori/framework/driver/browserfactory/WebDriverBrowserSelenium.java
@@ -72,6 +72,10 @@ public class WebDriverBrowserSelenium {
     }
 
     public WebDriver getWebDriver() {
+    	return getWebDriver(null);
+    }
+    
+    public WebDriver getWebDriver(String mobileDevice) {
         WebDriver driver = null;
         String testName = browsers.getTestName();
 
@@ -89,8 +93,8 @@ public class WebDriverBrowserSelenium {
             if (!StringUtils.isEmpty(browsers.getCaseExecutionId()))
                 caps.setCapability("name", browsers.getCaseExecutionId());
 
-            driver = getDriver(caps);
-
+            driver = getDriver(caps, mobileDevice);
+            
             if (driver != null) {
                 setProperties(driver);
             }
@@ -107,15 +111,15 @@ public class WebDriverBrowserSelenium {
         driver.manage().window().maximize();
     }
 
-    public WebDriver getDriver(final DesiredCapabilities caps)
+    public WebDriver getDriver(final DesiredCapabilities caps, String mobileDevice)
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         WebDriver driver;
-        final Method meth = getClass().getMethod(PREFIX_NAME_METHOD + browsers.getRemote(), Browsers.class, DesiredCapabilities.class);
-        driver = (WebDriver) meth.invoke(this, this.browsers, caps);
+        final Method meth = getClass().getMethod(PREFIX_NAME_METHOD + browsers.getRemote(), Browsers.class, DesiredCapabilities.class, String.class);
+        driver = (WebDriver) meth.invoke(this, this.browsers, caps, mobileDevice);
         return driver;
     }
 
-    public WebDriver getWebDriverRemoteYES(final Browsers navega, final DesiredCapabilities caps) {
+    public WebDriver getWebDriverRemoteYES(final Browsers navega, final DesiredCapabilities caps, final String mobileDevice) {
 
         WebDriver driver = null;
         try {
@@ -125,6 +129,12 @@ public class WebDriverBrowserSelenium {
                 for (String pref : extraPreferences.keySet()) {
                     String argument = StringUtils.isEmpty(extraPreferences.get(pref)) ? pref : pref + "=" + extraPreferences.get(pref);
                     options.addArguments(argument);
+                }
+                
+                if (!StringUtils.isEmpty(mobileDevice)) {
+                    Map<String, String> mobileEmulation = new HashMap<>();
+                    mobileEmulation.put("deviceName", mobileDevice);
+                    options.setExperimentalOption("mobileEmulation", mobileEmulation);
                 }
 
                 caps.setCapability(ChromeOptions.CAPABILITY, options);
@@ -140,7 +150,7 @@ public class WebDriverBrowserSelenium {
         return driver;
     }
 
-    public WebDriver getWebDriverRemoteNO(final Browsers navega, final DesiredCapabilities caps)
+    public WebDriver getWebDriverRemoteNO(final Browsers navega, final DesiredCapabilities caps, final String mobileDevice)
             throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException, ClassNotFoundException {
         Platform currentPlatform = caps.getPlatform();
         if (isWindowsPlatform(currentPlatform)) {
@@ -197,6 +207,12 @@ public class WebDriverBrowserSelenium {
             for (String key : extraPreferences.keySet()) {
                 String argument = StringUtils.isEmpty(extraPreferences.get(key)) ? key : key + "=" + extraPreferences.get(key);
                 options.addArguments(argument);
+            }
+            
+            if (!StringUtils.isEmpty(mobileDevice)) {
+                Map<String, String> mobileEmulation = new HashMap<>();
+                mobileEmulation.put("deviceName", mobileDevice);
+                options.setExperimentalOption("mobileEmulation", mobileEmulation);
             }
 
             try {

--- a/src/main/java/io/zahori/framework/files/properties/ZahoriProperties.java
+++ b/src/main/java/io/zahori/framework/files/properties/ZahoriProperties.java
@@ -105,6 +105,10 @@ public class ZahoriProperties {
     public String getChromeDriver() {
         return getProperty("zahori.webdriver.chrome.driver");
     }
+    
+    public String getEmulatedDeviceName() {
+    	return getProperty("zahori.webdriver.emulated.device.name");
+    }
 
     public String getTestUrl() {
         return getProperty("zahori.test.url");


### PR DESCRIPTION
## v0.1.17 (01-04-2022)
### Bug Fixes
- Se controla posible NPE al obtener path de evidencias
- Se controle posible NPE al construir objeto Browser

### Features
- ZAH-211: Importar evolución framework "viejo Zahorí"
	> Utilizar emulación de dispositivo móvil en Google Chrome a través de propiedad en zahori.properties [zahori.webdriver.emulated.device.name]
	
	> Inyección capabilities con nombre del test en ejecución a través de tag {{testName}}